### PR TITLE
Improve Record formatting

### DIFF
--- a/src/createFormatter.js
+++ b/src/createFormatter.js
@@ -4,6 +4,9 @@ const keyStyle = { style: "color:#881391" };
 module.exports = function createFormatter(Immutable) {
 
   function reference(any, config) {
+    if (any === undefined) {
+      return "undefined";
+    }
     return ["object", { object: any, config: config }]
   }
 

--- a/src/createFormatter.js
+++ b/src/createFormatter.js
@@ -94,8 +94,9 @@ module.exports = function createFormatter(Immutable) {
   };
 
   const recordFormatter = {
-    header() {
-      return ["span", "Record"];
+    header(record) {
+      const recordName = record._name || record.constructor.name || "Record";
+      return ["span", recordName];
     },
     hasBody: notEmpty,
     body(record) {


### PR DESCRIPTION
Addresses #6 and #8. @andrewdavey 

Uses the [same logic](https://github.com/facebook/immutable-js/blob/7c4483e30e8b9528562f6ef34f66bee6bfb3538d/src/Record.js#L151) Immutable does in `toString` to display record names.

<img width="511" alt="screen shot 2015-12-20 at 3 11 53 pm" src="https://cloud.githubusercontent.com/assets/478109/11919888/5dcb1340-a72c-11e5-9175-dd160df3c67e.png">