### PR TITLE
sort keys of (unordered) Maps

### DIFF
--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -23,7 +23,10 @@ export default function createFormatter(Immutable) {
   const hasBody = (collection, config) =>
     collection.size > 0 && !(config && config.noPreview);
 
-  const renderIterableBody = (collection, mapper) => {
+  const renderIterableBody = (collection, mapper, options = {}) => {
+    if (options.sorted) {
+      collection = collection.sortBy((value, key) => key);
+    }
     const children = collection
       .map(mapper)
       .toList()
@@ -123,7 +126,8 @@ export default function createFormatter(Immutable) {
     hasBody,
     body(o) {
       return renderIterableBody(o, (value, key) => 
-        ['li', {}, '{', reference(key), ' => ', reference(value), '}']
+        ['li', {}, '{', reference(key), ' => ', reference(value), '}'],
+        {sorted: true}
       );
     }
   };
@@ -151,7 +155,8 @@ export default function createFormatter(Immutable) {
     hasBody,
     body(o) {
       return renderIterableBody(o, value =>
-        ['li', reference(value)]
+        ['li', reference(value)],
+        {sorted: true}
       );
     }
   };


### PR DESCRIPTION
I'm used to JS Object entries being shown in sorted order in the console, so I made immutable-devtools sort Map and Set entries by key.  (This doesn't change the order of OrderedMaps or OrderedSets.)