### PR TITLE
use a regular module.exports in index

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "files": ["dist", "before.png", "after.png"],
   "scripts": {
+    "build": "webpack --config ./webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ if (typeof Immutable !== "undefined") {
 // I imagine most people are using Immutable as a CommonJS module though...
 
 let installed = false;
-export default function install(Immutable) {
+module.exports = function install(Immutable) {
   if (typeof window === "undefined") {
     throw new Error("Can only install immutable-devtools in a browser environment.");
   }


### PR DESCRIPTION
possibly a fix for #14 

I think using a regular common JS export will still work the same with ES6 imports and work as expected with normal common js imports.

Haven't gotten to give it a try with ES6 imports yet but I figured I'd put it up.

cc @andrewdavey @jazzdan