### PR TITLE
Make formatters work with Immutable v4

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <html>
   <head>
     <title>Immutable DevTools Demo</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.6/immutable.min.js"></script>
+    <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.6/immutable.min.js"></script> -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/4.0.0-rc.7/immutable.js"></script>
     <script src="dist/index.js"></script>
     <script id="demoScript">
       var MyRecord = Immutable.Record({

--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -20,8 +20,11 @@ export default function createFormatter(Immutable) {
   const renderIterableHeader = (iterable, name = 'Iterable') =>
     ['span', ['span', immutableNameStyle, name], ['span', `[${iterable.size}]`]];
 
+
+  const getKeySeq = collection => collection.toSeq().map((v, k) => k).toIndexedSeq()
+
   const hasBody = (collection, config) =>
-    collection.size > 0 && !(config && config.noPreview);
+    getKeySeq(collection).size > 0 && !(config && config.noPreview);
 
   const renderIterableBody = (collection, mapper, options = {}) => {
     if (options.sorted) {
@@ -50,8 +53,7 @@ export default function createFormatter(Immutable) {
       if (!changed) {
         inlinePreview = ['span', inlineValuesStyle, '{}'];
       } else {
-        const preview = record
-          .keySeq()
+        const preview = getKeySeq(record)
           .reduce((preview, key) => {
             if (Immutable.is(defaults.get(key), record.get(key)))
               return preview;
@@ -74,8 +76,7 @@ export default function createFormatter(Immutable) {
     hasBody,
     body(record) {
       const defaults = record.clear();
-      const children = record
-        .keySeq()
+      const children = getKeySeq(record)
         .map(key => {
           const style = Immutable.is(defaults.get(key), record.get(key))
             ? defaultValueKeyStyle : alteredValueKeyStyle;


### PR DESCRIPTION
`keySeq` and `size` don't work on Record anymore when using Immutable v4, so this change works around it. The code is still compatible with Immutable v3.

Before and after: https://imgur.com/a/vX9UB (Github image upload is broken for me)

The error about `set` is specific to the index.html example Record having a `set` key.