### PR TITLE
Support Immutable v4rc8

### DIFF
--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -32,8 +32,12 @@ export default function createFormatter(Immutable) {
     }
     const children = collection
       .map(mapper)
-      .toList()
-      .toJS();
+      .toList();
+
+    const jsList = []
+    // Can't just call toJS because that will also call toJS on children inside the list
+    children.forEach(child => jsList.push(child))
+
     return [ 'ol', listStyle, ...children ];
   }
 
@@ -77,6 +81,7 @@ export default function createFormatter(Immutable) {
     body(record) {
       const defaults = record.clear();
       const children = getKeySeq(record)
+        .toJS()
         .map(key => {
           const style = Immutable.is(defaults.get(key), record.get(key))
             ? defaultValueKeyStyle : alteredValueKeyStyle;
@@ -85,7 +90,7 @@ export default function createFormatter(Immutable) {
               ['span', style, key + ': '],
               reference(record.get(key))
             ]
-        }).toJS();
+        });
       return [ 'ol', listStyle, ...children ];
     }
   };


### PR DESCRIPTION
Immutable now calls toJS deeply even on immutable values contained in a
native array or object. This was broke displaying child notes, e.g. for
`Immutable.Record({bar: new Immutable.Map({a: 5}) })`.

https://github.com/facebook/immutable-js/pull/1369