### PR TITLE
Loosen Immutable library dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "webpack": "^1.12.4",
     "babel-loader": "^6.1.0",
     "babel-core": "^6.1.4",
-    "babel-preset-es2015": "^6.1.4"
+    "babel-preset-es2015": "^6.1.4",
+    "immutable": "^4.0.0-rc.9"
   },
   "repository" : {
     "type" : "git",

--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -8,6 +8,22 @@ const nullStyle = {style: 'color: #777'};
 
 export default function createFormatter(Immutable) {
 
+  const isRecord = maybeRecord => {
+    // Immutable v4
+    if (maybeRecord['@@__IMMUTABLE_RECORD__@@']) {
+      // There's also a Immutable.Record.isRecord we could use, but then the
+      // Immutable instance passed into createFormatter has to be the same
+      // version as the one used to create the Immutable object.
+      // That's especially a problem for the Chrome extension.
+      return true
+    }
+    // Immutable v3
+    return !!(
+      maybeRecord['@@__IMMUTABLE_KEYED__@@'] && 
+      maybeRecord['@@__IMMUTABLE_ITERABLE__@@'] &&
+      maybeRecord._defaultValues !== undefined)
+  }
+
   const reference = (object, config) => {
     if (typeof object === 'undefined')
       return ['span', nullStyle, 'undefined'];
@@ -43,7 +59,7 @@ export default function createFormatter(Immutable) {
 
   const RecordFormatter = {
     header(record, config) {
-      if (!(record instanceof Immutable.Record))
+      if (!(isRecord(record)))
         return null;
 
       const defaults = record.clear();

--- a/test.js
+++ b/test.js
@@ -1,0 +1,47 @@
+// Run `node --inspect --inspect-brk test.js`, open the debugger, and check everything renders correctly
+// Note that this will only test Immutable v4!
+
+var Immutable = require("immutable");
+
+var installDevTools = require("./dist");
+installDevTools(Immutable);
+
+class ABRecord extends Immutable.Record({a:1,b:2}) {
+    getAB() {
+        return this.a + this.b;
+    }
+}
+
+var Xyz = new Immutable.Map({a: new Immutable.Map({b:8})})
+console.log("Expand this and check child renders as a Map", Xyz)
+
+var Foo = Immutable.Record({bar: new Immutable.Map({a: 5}) })
+var f = Foo()
+console.log("Expand this and check child renders as a Map", f)
+
+var record = new ABRecord();
+var record2 = new ABRecord({a: 2});
+console.log(record);
+console.log(record2);
+
+var orderedMap = Immutable.OrderedMap({key: "value"});
+var orderedMap2 = Immutable.OrderedMap([["key", "value"], ["key2", "value2"]]);
+console.log(orderedMap);
+console.log(orderedMap2);
+
+var orderedSet = Immutable.OrderedSet(["hello", "aaa"]);
+console.log(orderedSet);
+
+var list = Immutable.List(["hello", "world"]);
+console.log(list)
+
+var map = Immutable.Map({hello: "world"})
+console.log(map)
+
+var set = Immutable.Set(["hello", "aaa"])
+console.log(set)
+
+var stack = Immutable.Stack(["hello", "aaa"])
+console.log(stack)
+
+debugger


### PR DESCRIPTION
Using `instanceof` to detect a `Record` only works if the library instance loaded on the page is the same as the one passed into `installDevtools`. That's not the case in the [Chrome extension](https://github.com/mattzeunert/immutable-object-formatter-extension).

This PR uses an alternative to `instanceof` and also adds a set of manual test cases to check code changes didn't break the formatters.