### PR TITLE
Address aggressive truncation in Scope panel

### DIFF
--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -95,7 +95,7 @@ export default function createFormatter(Immutable) {
           }, []);
         inlinePreview = ['span', inlineValuesStyle, '{', ...preview, '}'];
       }
-      return ['span',  {},
+      return ['span', {},
         ['span', immutableNameStyle, record._name || record.constructor.name || 'Record'],
         ' ', inlinePreview
       ];

--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -95,7 +95,7 @@ export default function createFormatter(Immutable) {
           }, []);
         inlinePreview = ['span', inlineValuesStyle, '{', ...preview, '}'];
       }
-      return ['span',  { style: 'position: relative'},
+      return ['span',  {},
         ['span', immutableNameStyle, record._name || record.constructor.name || 'Record'],
         ' ', inlinePreview
       ];

--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -1,9 +1,9 @@
-const listStyle = {style: 'list-style-type: none; padding: 0; margin: 0 0 0 12px; font-style: normal'};
-const immutableNameStyle = {style: 'color: rgb(232,98,0)'};
+const listStyle = {style: 'list-style-type: none; padding: 0; margin: 0 0 0 12px; font-style: normal; position: relative'};
+const immutableNameStyle = {style: 'color: rgb(232,98,0); position: relative'};
 const keyStyle = {style: 'color: #881391'};
 const defaultValueKeyStyle = {style: 'color: #777'};
 const alteredValueKeyStyle = {style: 'color: #881391; font-weight: bolder'};
-const inlineValuesStyle = {style: 'color: #777; font-style: italic'}
+const inlineValuesStyle = {style: 'color: #777; font-style: italic; position: relative'}
 const nullStyle = {style: 'color: #777'};
 
 export default function createFormatter(Immutable) {
@@ -95,7 +95,7 @@ export default function createFormatter(Immutable) {
           }, []);
         inlinePreview = ['span', inlineValuesStyle, '{', ...preview, '}'];
       }
-      return ['span', {},
+      return ['span',  { style: 'position: relative'},
         ['span', immutableNameStyle, record._name || record.constructor.name || 'Record'],
         ' ', inlinePreview
       ];


### PR DESCRIPTION
@andrewdavey 

At some point in the last few months an update to Chrome has made the extension start to truncate anything in the `Scope` panel that's larger than the panel. I'm not really sure what this change was and after spending a few hours looking for it I found nothing obvious in the Chrome changelogs.

I was able to fix this issue by adding `position: relative` to the top level `span` elements which effectively just ignores the wrapping elements truncation rules. The ellipsis still appears on top of the carrot but it's a minor issue compared to the data not showing up at all. I tried a bunch of other solutions and couldn't get anything to work quite as well as the `position: relative` so if anyone else has any suggestions I'd be happy to look into them

I think it used to cut off the record at the end of the line instead of wrapping it around to the next line which could be slightly concerning for larger records so if you think that's an issue I can look into ways to fix it.

I ran the test page and didn't see any regressions in my testing

## Example
| Before                                                                                                         | After                                                                                                          |
|----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/57279473/68065938-be8c2f00-fd06-11e9-9c92-65d600bc8b3a.png) | ![image](https://user-images.githubusercontent.com/57279473/68065896-2db55380-fd06-11e9-9393-fdce1856e03e.png) |
