### PR TITLE
"Null" string should be displayed as a string, not as null

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>Immutable DevTools Demo</title>
     <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/3.7.6/immutable.min.js"></script> -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/4.0.0-rc.7/immutable.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/immutable/5.0.3/immutable.js"></script>
     <script src="dist/index.js"></script>
     <script id="demoScript">
       var MyRecord = Immutable.Record({
@@ -70,6 +70,7 @@
       })
       console.log('Nested Records', nestedRecords)
 
+      console.log("Null string", Immutable.List.of("hello", "null", null, 'undefined', undefined));
     </script>
   </head>
   <body>

--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -34,7 +34,7 @@ export default function createFormatter(Immutable) {
   const reference = (object, config) => {
     if (typeof object === 'undefined')
       return ['span', nullStyle, 'undefined'];
-    else if (object === 'null')
+    else if (object === null)
       return ['span', nullStyle, 'null'];
 
     return ['object', {object, config}];


### PR DESCRIPTION
Fixes https://github.com/mattzeunert/immutable-object-formatter-extension/issues/20
Fixes #37 

### Actual

![yx81O8Z](https://github.com/user-attachments/assets/6b34ce65-4726-4d4f-93e4-236c1ca7ea6d)


### New comportment

![image](https://github.com/user-attachments/assets/3ea6c4a5-065e-47a4-8c07-f7eb6ee6ad52)
