### PR TITLE
Dark mode of console using `light-dark`

### DIFF
--- a/src/createFormatters.js
+++ b/src/createFormatters.js
@@ -1,10 +1,18 @@
+const orange = 'light-dark(rgb(232,98,0), rgb(255, 150, 50))';
+const purple = 'light-dark( #881391, #D48CE6)';
+const gray = 'light-dark(rgb(119,119,119), rgb(201, 201, 201))';
+
 const listStyle = {style: 'list-style-type: none; padding: 0; margin: 0 0 0 12px; font-style: normal; position: relative'};
-const immutableNameStyle = {style: 'color: rgb(232,98,0); position: relative'};
-const keyStyle = {style: 'color: #881391'};
-const defaultValueKeyStyle = {style: 'color: #777'};
-const alteredValueKeyStyle = {style: 'color: #881391; font-weight: bolder'};
-const inlineValuesStyle = {style: 'color: #777; font-style: italic; position: relative'}
-const nullStyle = {style: 'color: #777'};
+const immutableNameStyle = {
+  style: `color: ${orange}; position: relative`,
+};
+const keyStyle = { style: `color: ${purple}` };
+const defaultValueKeyStyle = { style: `color: ${gray}` };
+const alteredValueKeyStyle = { style: `color: ${purple}; font-weight: bolder` };
+const inlineValuesStyle = {
+  style: `color: ${gray}; font-style: italic; position: relative`,
+};
+const nullStyle = { style: `color: ${gray}` };
 
 export default function createFormatter(Immutable) {
 


### PR DESCRIPTION
The current colors works fine in light mode, but not in dark mode.

Following [this blogpost](https://nicolaschevobbe.com/2024/07/21/console-log-light-dark.html) from @nchevobbe I did implement dark mode for immutable-devtools.

### Current / light mode screenshot

![image](https://github.com/user-attachments/assets/4ff64b3b-2455-47c1-8596-2d6f4db0d448)

### Current version in dark mode

![image](https://github.com/user-attachments/assets/a1203210-eafd-4afb-9714-15da964e6221)


### New dark mode

![image](https://github.com/user-attachments/assets/c9a9e642-01c0-456c-a8af-fce94d2f45ac)
